### PR TITLE
라인 차트 구현

### DIFF
--- a/client/src/js/api/request.js
+++ b/client/src/js/api/request.js
@@ -57,3 +57,19 @@ export async function deletePaymentMethod(id) {
 		method: 'DELETE',
 	});
 }
+
+export async function getRecentHistory(year, month, categoryId) {
+	try {
+		const response = await fetch(
+			`${API_ENDPOINT}/history/recent?year=${year}&month=${month}&categoryId=${categoryId}`
+		);
+
+		if (!response.ok) {
+			throw new Error(`Request is not OK ${response.status}`);
+		}
+
+		return await response.json();
+	} catch (e) {
+		return e;
+	}
+}

--- a/client/src/js/api/request.js
+++ b/client/src/js/api/request.js
@@ -59,17 +59,7 @@ export async function deletePaymentMethod(id) {
 }
 
 export async function getRecentHistory(year, month, categoryId) {
-	try {
-		const response = await fetch(
-			`${API_ENDPOINT}/history/recent?year=${year}&month=${month}&categoryId=${categoryId}`
-		);
-
-		if (!response.ok) {
-			throw new Error(`Request is not OK ${response.status}`);
-		}
-
-		return await response.json();
-	} catch (e) {
-		return e;
-	}
+	return await fetchData(
+		`${API_ENDPOINT}/history/recent?year=${year}&month=${month}&categoryId=${categoryId}`
+	);
 }

--- a/client/src/js/components/Donut.js
+++ b/client/src/js/components/Donut.js
@@ -64,16 +64,18 @@ class Donut {
 			}
 
 			const categoryId = Number(donutHistoryItem.dataset.categoryId);
-			const history = await getRecentHistory(year, month, categoryId);
+			const recentHistory = await getRecentHistory(year, month, categoryId);
 			const chart = this.DOMElement.parentNode.querySelector(
 				'.line-chart__container'
 			);
 
 			if (chart) {
-				chart.replaceWith(new LineChart({ categoryId, history }).DOMElement);
+				chart.replaceWith(
+					new LineChart({ categoryId, recentHistory }).DOMElement
+				);
 			} else {
 				this.DOMElement.parentNode.appendChild(
-					new LineChart({ categoryId, history }).DOMElement
+					new LineChart({ categoryId, recentHistory }).DOMElement
 				);
 			}
 		});

--- a/client/src/js/components/Donut.js
+++ b/client/src/js/components/Donut.js
@@ -18,7 +18,6 @@ class Donut {
 	template(groupedHistory) {
 		const { totalExpense, categoryAndExpenseSumList } = groupedHistory;
 		if (!totalExpense) return `<div></div>`;
-
 		return `
 			<canvas></canvas>
 			<div class="donut__right">
@@ -27,7 +26,7 @@ class Donut {
 					${categoryAndExpenseSumList
 						.map(
 							(item) => `
-						<li>
+						<li data-category-id=${item.categoryId}>
 							<div>
 								<div class="category ${categoryObj[item.category]} bold-medium">${
 								item.category
@@ -44,6 +43,10 @@ class Donut {
 				</ul>
 			</div>
 		`;
+	}
+
+	setEvent() {
+		const donutHistory = this.DOMElement.querySelector('.donut__history');
 	}
 
 	setInitialCanvasSize() {

--- a/client/src/js/components/LineChart.js
+++ b/client/src/js/components/LineChart.js
@@ -1,0 +1,159 @@
+import store from '../store/store';
+
+class LineChart {
+	constructor(props) {
+		this.props = props;
+		this.DOMElement = document.createElement('div');
+		this.DOMElement.className = 'line-chart__container';
+		this.totalExpense = this.getTotalExpenseByMonth();
+		this.unsubscribe = store.subscribe('history', this.init.bind(this));
+		this.render();
+	}
+
+	init() {
+		this.unsubscribe();
+		this.DOMElement.remove();
+	}
+
+	template() {
+		return `<canvas class="line-chart"></canvas>`;
+	}
+
+	render() {
+		this.DOMElement.innerHTML = this.template();
+		this.drawLineChart();
+	}
+
+	getExpenseValues() {
+		const result = [];
+		const { totalExpense } = this;
+
+		Object.keys(totalExpense)
+			.sort((a, b) => a - b)
+			.forEach((year) =>
+				Object.keys(totalExpense[year])
+					.sort((a, b) => a - b)
+					.forEach((month) => {
+						result.push(totalExpense[year][month]);
+					})
+			);
+
+		return result;
+	}
+
+	drawLineChart() {
+		const canvas = this.DOMElement.querySelector('.line-chart');
+		const context = canvas.getContext('2d'); // 배경 렌더링
+		const [NUM_OF_COLOUMNS, NUM_OF_ROWS] = [24, 12];
+		const [CELL_WIDTH, CELL_HEIGHT] = [33, 26];
+		const [X_PADDING, Y_PADDING] = [32, 30];
+		const values = this.getExpenseValues();
+		canvas.width = NUM_OF_COLOUMNS * CELL_WIDTH + 2 * X_PADDING;
+		canvas.height = NUM_OF_ROWS * CELL_HEIGHT + 2 * Y_PADDING;
+		const chartWidth = canvas.width - X_PADDING;
+		const chartHeight = canvas.height - Y_PADDING;
+
+		context.fillStyle = '#FCFCFC';
+		context.fillRect(0, 0, canvas.width, canvas.height);
+
+		context.beginPath();
+
+		// draw Row
+		for (let row = 0; row <= NUM_OF_ROWS; row++) {
+			const y = row * CELL_HEIGHT + Y_PADDING;
+			context.moveTo(X_PADDING, y);
+			context.lineTo(chartWidth, y);
+		}
+
+		// draw Column
+		context.fillStyle = '#8D9393';
+		context.textAlign = 'center';
+		context.font = '10pt Do Hyeon';
+
+		for (let col = 0; col <= NUM_OF_COLOUMNS; col++) {
+			const x = col * CELL_WIDTH + X_PADDING;
+			context.moveTo(x, Y_PADDING);
+			context.lineTo(x, chartHeight);
+
+			if (col > 0 && col % 2) {
+				context.fillText(
+					'month',
+					CELL_WIDTH * col + X_PADDING,
+					canvas.height - 10
+				);
+			}
+		}
+
+		context.lineWidth = 1;
+		context.strokeStyle = '#c0c0c0';
+		context.stroke();
+
+		let maxVal = 0;
+
+		for (let i = 0; i < values.length; i++) {
+			if (values[i] > maxVal) maxVal = values[i];
+		} // 비율 계산을 위해 최대값 구하기
+
+		maxVal = maxVal * 1.2; // 최대값 기준 스케일링
+
+		const points = [];
+
+		for (let i = 0; i < values.length; i++) {
+			const val = values[i];
+			const px = CELL_WIDTH * (i * 2 + 1) + X_PADDING;
+			const py = chartHeight - chartHeight * (val / maxVal);
+			points.push({ x: px, y: py });
+		} // 점 좌표 계산
+
+		context.beginPath();
+		context.moveTo(points[0].x, points[0].y);
+
+		// 0번으로 Move후 각 point에 따라 선 그리기
+		for (let i = 1; i < points.length; i++) {
+			context.lineTo(points[i].x, points[i].y);
+		}
+
+		context.lineWidth = 2;
+		context.strokeStyle = '#A0E1E0';
+		context.stroke();
+
+		context.textAlign = 'center';
+		context.font = '10pt Do Hyeon';
+
+		for (let i = 0; i < points.length; i++) {
+			const point = points[i];
+			const value = values[i].toLocaleString();
+			context.fillStyle = '#626666';
+			context.fillText(value, point.x, point.y - 15);
+			context.fillStyle = '#2AC1BC';
+			context.beginPath();
+			context.arc(point.x, point.y, 4, 0, 2 * Math.PI);
+			context.fill();
+		} // 점, 숫자 그리기
+	}
+
+	getTotalExpenseByMonth() {
+		const result = {};
+		const history = this.props.history;
+
+		for (const year in history) {
+			if (!result[year]) {
+				result[year] = {};
+			}
+
+			for (const month in history[year]) {
+				if (!result[year][month]) {
+					result[year][month] = 0;
+				}
+
+				result[year][month] += history[year][month].reduce((total, item) => {
+					return total + item.price;
+				}, 0);
+			}
+		}
+
+		return result;
+	}
+}
+
+export default LineChart;

--- a/client/src/js/components/LineChart.js
+++ b/client/src/js/components/LineChart.js
@@ -7,6 +7,7 @@ import {
 	X_PADDING,
 	Y_PADDING,
 } from '../constants/line_chart.js';
+import { MAX_MONTH } from '../constants/date';
 
 class LineChart {
 	constructor(props) {
@@ -36,10 +37,12 @@ class LineChart {
 
 	getMonthsColumnLabel(months) {
 		const lastMonth = Number(months[months.length - 1]);
-		const result = new Array(12 - months.length)
+		const result = new Array(MAX_MONTH - months.length)
 			.fill(0)
 			.map((_, i) =>
-				lastMonth + i + 1 > 12 ? lastMonth + i + 1 - 12 : lastMonth + i + 1
+				lastMonth + i + 1 > MAX_MONTH
+					? lastMonth + i + 1 - MAX_MONTH
+					: lastMonth + i + 1
 			);
 
 		return months.concat(result);
@@ -49,7 +52,6 @@ class LineChart {
 		const values = [];
 		const months = [];
 		const { totalExpense } = this;
-
 		Object.keys(totalExpense)
 			.sort((a, b) => a - b)
 			.forEach((year) =>
@@ -105,7 +107,9 @@ class LineChart {
 		let maxVal = 0;
 
 		for (let i = 0; i < values.length; i++) {
-			if (values[i] > maxVal) maxVal = values[i];
+			if (values[i] > maxVal) {
+				maxVal = values[i];
+			}
 		}
 
 		return maxVal * 1.2;
@@ -189,9 +193,7 @@ class LineChart {
 				}
 
 				result[year][month] += recentHistory[year][month].reduce(
-					(total, item) => {
-						return total + item.price;
-					},
+					(total, item) => total + item.price,
 					0
 				);
 			}

--- a/client/src/js/constants/line_chart.js
+++ b/client/src/js/constants/line_chart.js
@@ -1,0 +1,3 @@
+export const [NUM_OF_COLOUMNS, NUM_OF_ROWS] = [24, 12];
+export const [CELL_WIDTH, CELL_HEIGHT] = [33, 26];
+export const [X_PADDING, Y_PADDING] = [32, 30];

--- a/client/src/js/index.js
+++ b/client/src/js/index.js
@@ -7,6 +7,7 @@ import '@styles/history_form.css';
 import '@styles/Calendar.css';
 import '@styles/PaymentMethodModal.css';
 import '@styles/Donut.css';
+import '@styles/LineChart.css';
 import renderHome from './pages/home.js';
 import Router from './core/router.js';
 import store from './store/store.js';

--- a/client/src/js/utils/history.js
+++ b/client/src/js/utils/history.js
@@ -25,10 +25,14 @@ export function getGroupedHistoryByExpense(history) {
 		if (item.isIncome) return;
 
 		if (!result.has(item.category)) {
-			result.set(item.category, 0);
+			result.set(item.category, { categoryId: item.categoryId, expenseSum: 0 });
 		}
 
-		result.set(item.category, result.get(item.category) + item.price);
+		const original = result.get(item.category);
+		result.set(item.category, {
+			...original,
+			expenseSum: original.expenseSum + item.price,
+		});
 		totalExpense += item.price;
 	});
 
@@ -37,7 +41,8 @@ export function getGroupedHistoryByExpense(history) {
 		categoryAndExpenseSumList: [...result]
 			.map((item) => ({
 				category: item[0],
-				expenseSum: item[1],
+				categoryId: item[1].categoryId,
+				expenseSum: item[1].expenseSum,
 			}))
 			.sort((a, b) => b.expenseSum - a.expenseSum),
 	};

--- a/client/src/styles/LineChart.css
+++ b/client/src/styles/LineChart.css
@@ -1,0 +1,8 @@
+.line-chart__container {
+	margin: 4rem auto;
+	background-color: var(--color-white);
+	max-width: 848px;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+}

--- a/server/src/api/history/history.ctrl.js
+++ b/server/src/api/history/history.ctrl.js
@@ -37,28 +37,25 @@ export function updateHistory(req, res) {
   res.status(200).json({ id: 1, ...historyContent });
 }
 
-export function getRecentHistory(req, res) {
-  const { year, month, category } = req.query;
-  const startTime = getStartTime(year, month);
-  const history = createRecentHistory(startTime);
+export async function getRecentHistory(req, res) {
+  const { year, month, categoryId } = req.query;
+  const data = await historyDAO.getRecentHistory(year, month, categoryId);
+  const history = {};
 
-  for (const year in history) {
-    for (const month in history[year]) {
-      history[year][month] = history[year][month].filter(
-        (item) => item.category === category
-      );
+  data.forEach((item) => {
+    const year = item.date.getFullYear();
+    const month = item.date.getMonth() + 1;
+
+    if (!history[year]) {
+      history[year] = {};
     }
-  }
+
+    if (!history[year][month]) {
+      history[year][month] = [];
+    }
+
+    history[year][month].push(item);
+  });
 
   res.status(200).json(history);
-}
-
-function getStartTime(year, month) {
-  const startMonth = month - 6;
-
-  if (startMonth <= 0) {
-    return `${year - 1}-${startMonth + 12}`;
-  }
-
-  return `${year}-${startMonth < 10 ? '0' + startMonth : startMonth}`;
 }

--- a/server/src/db/DAO/history_DAO.js
+++ b/server/src/db/DAO/history_DAO.js
@@ -22,7 +22,7 @@ async function insertHistory(history) {
 async function readHistoryByYearMonth(month, year) {
   try {
     const [rows] = await promisePool.execute(
-      `SELECT h.id, h.date, h.content, h.paymentMethod, h.price, c.name as category, c.isIncome FROM HISTORY AS h
+      `SELECT h.id, h.date, h.content, h.paymentMethod, h.price, c.name as category, c.id as categoryId, c.isIncome FROM HISTORY AS h
          LEFT JOIN CATEGORY AS c ON h.categoryId = c.id
          WHERE MONTH(date) = ${month} AND YEAR(date) = ${year}
          ORDER BY date DESC

--- a/server/src/db/DAO/history_DAO.js
+++ b/server/src/db/DAO/history_DAO.js
@@ -65,14 +65,14 @@ async function updateHistoryById(history) {
 }
 
 async function getRecentHistory(year, month, categoryId) {
-  const RECENT_MONTH = 6;
-  const date = timeConverter(new Date(year, month - 1));
+  const RECENT_MONTH = 7;
+  const date = timeConverter(new Date(year, month));
 
   try {
     const [rows] = await promisePool.execute(
       `SELECT h.id, h.date, h.content, h.paymentMethod, h.price, c.name as category, c.isIncome FROM HISTORY AS h
       LEFT JOIN CATEGORY AS c ON h.categoryId = c.id
-      WHERE h.categoryId = ${categoryId} AND date > DATE_SUB("${date}", INTERVAL ${RECENT_MONTH} MONTH)
+      WHERE h.categoryId = ${categoryId} AND date <= "${date}" AND date >= DATE_SUB("${date}", INTERVAL ${RECENT_MONTH} MONTH)
       ORDER BY date DESC
       `
     );


### PR DESCRIPTION
# ✨ 구현 기능 명세
- 백엔드에서 받은 6개월 간의 데이터를 기준으로 라인 차트를 생성합니다.
- 백엔드 recentHistory 요청의 API를 명세에 맞게 수정했습니다.
- 불러온 action에 맞게 reducer도 추가했습니다.

# 😭 어려웠던 점
- 캔버스를 다루는데 조금 미숙해서 까다로웠습니다
- 6개월 간의 데이터를 가공해서 각각 월의 총합을 구하고 그것을 그래프의 라벨로 다는 과정도 까다로웠습니다.
- 좌표 값을 계산해야해서 그 부분도 maxValue를 기준으로 상대적인 좌표를 생성했습니다.

# ⏰ 실제 소요 시간
6h 30m