### PR TITLE
통계 페이지 하단 리스트 렌더링

### DIFF
--- a/client/src/js/components/HistoryContainer.js
+++ b/client/src/js/components/HistoryContainer.js
@@ -3,7 +3,7 @@ import icons from '../constants/icons';
 import store from '../store/store';
 import { getGroupedHistoryByDay, getMonthTotalMoney } from '../utils/history';
 
-class HistoryList {
+class HistoryContainer {
 	constructor(props = {}) {
 		this.DOMElement = document.createElement('main');
 		this.props = props;
@@ -152,4 +152,4 @@ class HistoryList {
 	}
 }
 
-export default HistoryList;
+export default HistoryContainer;

--- a/client/src/js/components/HistoryForm.js
+++ b/client/src/js/components/HistoryForm.js
@@ -53,6 +53,7 @@ class HistoryForm {
 			const isIncome = historyIsIncome.checked;
 			const paymentMethod = historyPaymentMethod.value;
 			const price = Number(historyPrice.value.replace(/,/g, ''));
+			const currentMonth = store.getState('month');
 
 			const newHistory = await addHistory({
 				date,
@@ -65,20 +66,22 @@ class HistoryForm {
 			this.DOMElement.reset();
 			this.disalbeSubmitButton();
 
-			const [_year, _month, day] = date.split('-');
+			const [_year, month, day] = date.split('-');
 
-			store.dispatch(
-				action.addHistory({
-					id: newHistory.id,
-					day: Number(day),
-					category,
-					categoryId,
-					content,
-					paymentMethod,
-					isIncome,
-					price,
-				})
-			);
+			if (Number(month) === Number(currentMonth)) {
+				store.dispatch(
+					action.addHistory({
+						id: newHistory.id,
+						day: Number(day),
+						category,
+						categoryId,
+						content,
+						paymentMethod,
+						isIncome,
+						price,
+					})
+				);
+			}
 		});
 	}
 

--- a/client/src/js/components/HistoryList.js
+++ b/client/src/js/components/HistoryList.js
@@ -1,0 +1,82 @@
+import category from '../constants/category';
+import store from '../store/store';
+
+class HistoryList {
+	constructor(props) {
+		this.props = props;
+		this.DOMElement = document.createElement('ol');
+		store.subscribe('month', this.render.bind(this));
+		this.render();
+	}
+
+	getSortedDayList(groupedHistory) {
+		return Object.keys(groupedHistory).sort((a, b) => b - a);
+	}
+
+	getDailyTotalMoney(filteredHistory, day) {
+		return `
+					${
+						filteredHistory[day].incomeSum && !this.props.isIncomeFiltered
+							? `수입 ${filteredHistory[day].incomeSum.toLocaleString()}`
+							: ''
+					}
+					${
+						filteredHistory[day].expenseSum && !this.props.isExpenseFiltered
+							? `지출 ${filteredHistory[day].expenseSum.toLocaleString()}`
+							: ''
+					}
+				`;
+	}
+
+	makeHistoryItems(item) {
+		return `<li class="history__item bold-medium">
+		<div>
+			<span class="category ${category[item.category]} bold-small">${
+			item.category
+		}</span>
+			<span>${item.content}</span>
+		</div>
+		<div>
+			${item.paymentMethod}
+		</div>
+		<div>
+			${item.isIncome ? '' : '-'}${item.price.toLocaleString()}원
+		</div>
+	</li>`;
+	}
+
+	template() {
+		const month = store.getState('month');
+		const { filteredHistory } = this.props;
+
+		return `
+    ${this.getSortedDayList(filteredHistory)
+			.map(
+				(day) => `<li class="history__day bold-medium">
+        <div class="history__day-meta">
+          <div>${month}월 ${day}일</div>
+          <div class="history__day-total">
+            ${
+							this.props.hideTotal
+								? ''
+								: this.getDailyTotalMoney(filteredHistory, day)
+						}
+          </div>
+        </div>
+        <ul>
+          ${filteredHistory[day].history
+						.map((item) => this.makeHistoryItems(item))
+						.join('')}
+        </ul>
+      </li>`
+			)
+			.join('')}
+  `;
+	}
+
+	render() {
+		this.DOMElement.innerHTML = this.template();
+	}
+}
+
+export default HistoryList;

--- a/client/src/js/components/LineChart.js
+++ b/client/src/js/components/LineChart.js
@@ -8,6 +8,8 @@ import {
 	Y_PADDING,
 } from '../constants/line_chart.js';
 import { MAX_MONTH } from '../constants/date';
+import { getFilteredHistory, getGroupedHistoryByDay } from '../utils/history';
+import HistoryList from './HistoryList';
 
 class LineChart {
 	constructor(props) {
@@ -31,8 +33,17 @@ class LineChart {
 	}
 
 	render() {
+		const history = store.getState('history');
+		const groupedHistory = getGroupedHistoryByDay(history);
+		const filteredHistory = getFilteredHistory(
+			groupedHistory,
+			(item) => Number(item.categoryId) === this.props.categoryId
+		);
 		this.DOMElement.innerHTML = this.template();
 		this.drawLineChart();
+		this.DOMElement.appendChild(
+			new HistoryList({ filteredHistory, hideTotal: true }).DOMElement
+		);
 	}
 
 	getMonthsColumnLabel(months) {

--- a/client/src/js/pages/home.js
+++ b/client/src/js/pages/home.js
@@ -1,10 +1,10 @@
 import Header from '../components/Header';
 import HistoryForm from '../components/HistoryForm';
-import HistoryList from '../components/HistoryList';
+import HistoryContainer from '../components/HistoryContainer';
 
 export default function renderHome() {
 	const app = document.querySelector('#app');
 	app.appendChild(new Header().DOMElement);
 	app.appendChild(new HistoryForm().DOMElement);
-	app.appendChild(new HistoryList().DOMElement);
+	app.appendChild(new HistoryContainer().DOMElement);
 }

--- a/client/src/js/utils/history.js
+++ b/client/src/js/utils/history.js
@@ -59,3 +59,18 @@ export function getMonthTotalMoney(groupedHistory) {
 
 	return result;
 }
+
+export function getFilteredHistory(groupedHistory, filterCallback) {
+	const filteredHistory = { ...groupedHistory };
+
+	for (const day in groupedHistory) {
+		filteredHistory[day].history =
+			groupedHistory[day].history.filter(filterCallback);
+
+		if (!filteredHistory[day].history.length) {
+			delete filteredHistory[day];
+		}
+	}
+
+	return filteredHistory;
+}

--- a/client/src/styles/LineChart.css
+++ b/client/src/styles/LineChart.css
@@ -1,8 +1,18 @@
 .line-chart__container {
-	margin: 4rem auto;
-	background-color: var(--color-white);
+	margin: 0 auto;
 	max-width: 848px;
 	display: flex;
 	flex-direction: column;
 	align-items: center;
+}
+
+.line-chart__container canvas {
+	margin-bottom: 2rem;
+	border: 1px solid var(--color-gray-200);
+	box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.1), 0px 4px 20px rgba(0, 0, 0, 0.1);
+	border-radius: 10px;
+}
+
+.line-chart__container ol {
+	width: 100%;
 }


### PR DESCRIPTION
# ✨ 구현 기능 명세
- 통계 페이지 하단에 해당 월과 카테고리에 맞는 리스트를 렌더링한다.

# 😭 어려웠던 점
- 기존 리스트 컴포넌트가 의존성이 너무 강해서 원래 있던 컴포넌트에서 분리하기 힘들었다.

<!-- 정확하지 않아도 좋으나 점점 구체화하면 좋을 것 같습니다. 데이터 쌓기! -->

# ⏰ 실제 소요 시간
30m

# 🚧 PR 특이 사항
Closes #49 