### PR TITLE
수입, 지출 폼의 +, - 폼에 따라 카테고리가 필터링 되도록 수정

### DIFF
--- a/client/src/js/components/HistoryForm.js
+++ b/client/src/js/components/HistoryForm.js
@@ -159,6 +159,10 @@ class HistoryForm {
 		this.setEvent();
 	}
 
+	resetHistoryCategory() {
+		this.DOMElement.querySelector('#historyCategory').value = '';
+	}
+
 	setEvent() {
 		const categoryLabel = this.DOMElement.querySelector(
 			'label[for="historyCategory"]'
@@ -228,6 +232,7 @@ class HistoryForm {
 
 		incomeToggleButton.addEventListener('click', () => {
 			this.DOMElement.classList.toggle('income-mode');
+			this.resetHistoryCategory();
 		});
 
 		priceInput.addEventListener('input', ({ target }) => {

--- a/client/src/js/components/HistoryForm.js
+++ b/client/src/js/components/HistoryForm.js
@@ -142,7 +142,7 @@ class HistoryForm {
 						id="historyPrice"
 						type="text"
 						placeholder="입력하세요"
-						class="body-regular"
+						class="history__form-price body-regular"
 						autocomplete="off"
 					/>
 					<span class="body-regular">원</span>
@@ -172,7 +172,10 @@ class HistoryForm {
 		const paymentMethodDropdown = paymentMethodLabel.querySelector(
 			'.history__form-dropdown'
 		);
-		const priceInput = this.DOMElement.querySelector('#historyPrice');
+		const incomeToggleButton = this.DOMElement.querySelector(
+			'.history__form-income-toggle'
+		);
+		const priceInput = this.DOMElement.querySelector('.history__form-price');
 
 		categoryLabel.addEventListener('click', (e) => {
 			e.preventDefault();
@@ -221,6 +224,10 @@ class HistoryForm {
 			} else {
 				addPaymentMethodToInput(paymentMethodLabel, dropdownItem);
 			}
+		});
+
+		incomeToggleButton.addEventListener('click', () => {
+			this.DOMElement.classList.toggle('income-mode');
 		});
 
 		priceInput.addEventListener('input', ({ target }) => {
@@ -282,7 +289,7 @@ function setDropdownElement(isPaymentMethod) {
 	<ul class="history__form-dropdown">
 		${dropdownContent
 			.map(
-				(item) => `<li data-id=${item.id}>
+				(item) => `<li data-id=${item.id} data-is-income=${item.isIncome}>
 			<span>${item.name}</span>
 			${
 				isPaymentMethod

--- a/client/src/styles/history_form.css
+++ b/client/src/styles/history_form.css
@@ -81,6 +81,20 @@
 	display: block;
 }
 
+.history__form:not(.income-mode)
+	label
+	.history__form-dropdown
+	li[data-is-income='1'] {
+	display: none;
+}
+
+.history__form.income-mode
+	label
+	.history__form-dropdown
+	li[data-is-income='0'] {
+	display: none;
+}
+
 .history__form label .history__form-dropdown li {
 	display: flex;
 	align-items: center;
@@ -174,7 +188,7 @@
 	padding-bottom: 4px;
 }
 
-#historyPrice {
+.history__form-price {
 	text-align: right;
 	padding-right: 0.5rem;
 }

--- a/client/src/styles/history_form.css
+++ b/client/src/styles/history_form.css
@@ -66,6 +66,7 @@
 }
 
 .history__form label .history__form-dropdown {
+	overflow: hidden;
 	position: absolute;
 	display: none;
 	width: 100%;


### PR DESCRIPTION
# ✨ 구현 기능 명세

수입, 지출 폼의 +, - 폼에 따라 카테고리가 필터링 되도록 수정했습니다.

# ⏰ 실제 소요 시간

30m

# 🚧 PR 특이 사항

Closes #50 