### PR TITLE
결제 수단 추가, 삭제 시 기존 상태 유지

### DIFF
--- a/client/src/js/components/HistoryForm.js
+++ b/client/src/js/components/HistoryForm.js
@@ -258,41 +258,7 @@ class HistoryForm extends Component {
 					{
 						isPaymentMethod: true,
 						onClear,
-						onClick: (event) => {
-							const dropdownItem = event.target;
-							if (dropdownItem.className === 'payment-method-add') {
-								new Modal({
-									title: '추가하실 결제수단을 적어주세요.',
-									content: '',
-									modalType: MODAL_TYPE.add,
-									onSubmit: async (value) => {
-										const res = await addPaymentMethod(value);
-										store.dispatch(
-											action.addPaymentMethod({
-												id: res.id,
-												name: value,
-											})
-										);
-									},
-								});
-							} else if (dropdownItem.className === 'payment-method-delete') {
-								const li = dropdownItem.closest('li');
-								const id = li.dataset.id;
-								const content = li.querySelector('span').innerText;
-
-								new Modal({
-									title: '해당 결제수단을 삭제하시겠습니까?',
-									content,
-									modalType: MODAL_TYPE.remove,
-									onSubmit: async () => {
-										const res = await deletePaymentMethod(id);
-										store.dispatch(action.deletePaymentMethod({ id: res.id }));
-									},
-								});
-							} else {
-								addPaymentMethodToInput(paymentMethodLabel, dropdownItem);
-							}
-						},
+						onClick: showPaymentMethodModal,
 					}
 				);
 				this.setChild(this.paymentMethodDropdown);
@@ -331,6 +297,42 @@ function addPaymentMethodToInput(label, dropdownItem) {
 		input.value = dropdownItem.innerText || '';
 
 		input.closest('form').dispatchEvent(new Event('input'));
+	}
+}
+
+function showPaymentMethodModal(event) {
+	const dropdownItem = event.target;
+	if (dropdownItem.className === 'payment-method-add') {
+		new Modal({
+			title: '추가하실 결제수단을 적어주세요.',
+			content: '',
+			modalType: MODAL_TYPE.add,
+			onSubmit: async (value) => {
+				const res = await addPaymentMethod(value);
+				store.dispatch(
+					action.addPaymentMethod({
+						id: res.id,
+						name: value,
+					})
+				);
+			},
+		});
+	} else if (dropdownItem.className === 'payment-method-delete') {
+		const li = dropdownItem.closest('li');
+		const id = li.dataset.id;
+		const content = li.querySelector('span').innerText;
+
+		new Modal({
+			title: '해당 결제수단을 삭제하시겠습니까?',
+			content,
+			modalType: MODAL_TYPE.remove,
+			onSubmit: async () => {
+				const res = await deletePaymentMethod(id);
+				store.dispatch(action.deletePaymentMethod({ id: res.id }));
+			},
+		});
+	} else {
+		addPaymentMethodToInput(paymentMethodLabel, dropdownItem);
 	}
 }
 

--- a/client/src/js/components/HistoryForm.js
+++ b/client/src/js/components/HistoryForm.js
@@ -258,7 +258,8 @@ class HistoryForm extends Component {
 					{
 						isPaymentMethod: true,
 						onClear,
-						onClick: showPaymentMethodModal,
+						onClick: (event) =>
+							showPaymentMethodModal(event, paymentMethodLabel),
 					}
 				);
 				this.setChild(this.paymentMethodDropdown);
@@ -300,7 +301,7 @@ function addPaymentMethodToInput(label, dropdownItem) {
 	}
 }
 
-function showPaymentMethodModal(event) {
+function showPaymentMethodModal(event, paymentMethodLabel) {
 	const dropdownItem = event.target;
 	if (dropdownItem.className === 'payment-method-add') {
 		new Modal({

--- a/client/src/js/components/HistoryFormDropdown.js
+++ b/client/src/js/components/HistoryFormDropdown.js
@@ -1,0 +1,60 @@
+import Component from '../core/Component';
+
+class HistoryFormDropdown extends Component {
+	constructor(container, props) {
+		super();
+		this.DOMElement = document.createElement('ul');
+		this.DOMElement.className = 'history__form-dropdown';
+		this.props = props;
+		if (props.isPaymentMethod) {
+			this.subscribe('paymentMethod', this.render.bind(this));
+		} else {
+			this.subscribe('category', this.render.bind(this));
+		}
+		container.appendChild(this.DOMElement);
+		this.render();
+		this.setEvent();
+	}
+
+	template() {
+		const { isPaymentMethod } = this.props;
+		const state = isPaymentMethod ? 'paymentMethod' : 'category';
+		const dropdownContent = this.getState(state);
+
+		return `
+			${dropdownContent
+				.map(
+					(item) => `<li data-id=${item.id} ${
+						isPaymentMethod ? '' : `data-is-income=${item.isIncome}`
+					}>
+				<span>${item.name}</span>
+				${
+					isPaymentMethod
+						? `<button class="payment-method-delete" type="button"></button>`
+						: ''
+				}
+			</li>`
+				)
+				.join('')}
+			${isPaymentMethod ? `<li class="payment-method-add">추가하기</li>` : ''}
+		`;
+	}
+
+	render() {
+		this.DOMElement.innerHTML = this.template();
+	}
+
+	setEvent() {
+		this.DOMElement.addEventListener('click', (event) => {
+			this.props.onClick(event);
+			if (
+				!event.target.closest('.payment-method-add') &&
+				!event.target.closest('.payment-method-delete')
+			) {
+				this.props.onClear();
+			}
+		});
+	}
+}
+
+export default HistoryFormDropdown;

--- a/client/src/js/core/Component.js
+++ b/client/src/js/core/Component.js
@@ -25,13 +25,15 @@ class Component {
 	}
 
 	clearChildren() {
-		this.childComponents.forEach((childComponent) => {
-			childComponent.unsubscribe.forEach((u) => u());
-			childComponent.clearChildren();
-			childComponent.DOMElement.remove();
-		});
-
+		this.childComponents.forEach(clear);
 		this.childComponents = [];
+	}
+
+	clearChild(childComponent) {
+		clear(childComponent);
+		this.childComponents = this.childComponents.filter(
+			(component) => component !== childComponent
+		);
 	}
 
 	clearSelf() {
@@ -39,6 +41,12 @@ class Component {
 		this.unsubscribe.forEach((u) => u());
 		this.clearChildren();
 	}
+}
+
+function clear(childComponent) {
+	childComponent.unsubscribe.forEach((u) => u());
+	childComponent.clearChildren();
+	childComponent.DOMElement.remove();
 }
 
 export default Component;

--- a/client/src/styles/HistoryForm.css
+++ b/client/src/styles/HistoryForm.css
@@ -72,7 +72,6 @@
 .history__form label .history__form-dropdown {
 	overflow: hidden;
 	position: absolute;
-	display: none;
 	width: 100%;
 	top: 5rem;
 	left: 0;
@@ -80,10 +79,6 @@
 	border: 1px solid var(--color-gray-200);
 	box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.1), 0px 4px 20px rgba(0, 0, 0, 0.1);
 	border-radius: 10px;
-}
-
-.history__form label .history__form-dropdown.show {
-	display: block;
 }
 
 .payment-method-delete::after {


### PR DESCRIPTION
# ✨ 구현 기능 명세

- 결제 수단 추가 후 드롭다운이 닫히지 않도록 수정
- 결제수단 추가 후 기존 폼이 유지되도록 수정

# 😭 어려웠던 점

드롭다운 컴포넌트를 분리하는 게 어려웠어요
<!-- 정확하지 않아도 좋으나 점점 구체화하면 좋을 것 같습니다. 데이터 쌓기! -->

# ⏰ 실제 소요 시간

1h 30m

# 🚧 PR 특이 사항

Closes #57 