### PR TITLE
결제 수단 삭제 로직 업데이트

### DIFF
--- a/client/src/js/components/HistoryForm.js
+++ b/client/src/js/components/HistoryForm.js
@@ -10,6 +10,7 @@ import Component from '../core/Component';
 import setLoadingInRequest from '../utils/request_loader';
 import { addPaymentMethod, deletePaymentMethod } from '../api/payment_method';
 import HistoryFormDropdown from './HistoryFormDropdown';
+import { IsPaymentMethodExist } from '../utils/payment_method';
 
 class HistoryForm extends Component {
 	constructor() {
@@ -309,7 +310,12 @@ function showPaymentMethodModal(event, paymentMethodLabel) {
 			content: '',
 			modalType: MODAL_TYPE.add,
 			onSubmit: async (value) => {
+				if (IsPaymentMethodExist(value)) {
+					return;
+				}
+
 				const res = await addPaymentMethod(value);
+
 				store.dispatch(
 					action.addPaymentMethod({
 						id: res.id,
@@ -327,9 +333,10 @@ function showPaymentMethodModal(event, paymentMethodLabel) {
 			title: '해당 결제수단을 삭제하시겠습니까?',
 			content,
 			modalType: MODAL_TYPE.remove,
-			onSubmit: async () => {
+			onSubmit: async (value) => {
 				const res = await deletePaymentMethod(id);
 				store.dispatch(action.deletePaymentMethod({ id: res.id }));
+				store.dispatch(action.deletePaymentMethodInHistory({ value }));
 			},
 		});
 	} else {

--- a/client/src/js/store/action.js
+++ b/client/src/js/store/action.js
@@ -86,6 +86,13 @@ function resetHistoryFormData() {
 	};
 }
 
+function deletePaymentMethodInHistory(payload) {
+	return {
+		type: 'DELETE_PAYMENT_METHOD_IN_HISTORY',
+		payload,
+	};
+}
+
 export default {
 	getCurrentMonthData,
 	getAllCategory,
@@ -100,4 +107,5 @@ export default {
 	deleteHistory,
 	updateHistoryFormData,
 	resetHistoryFormData,
+	deletePaymentMethodInHistory,
 };

--- a/client/src/js/store/reducer.js
+++ b/client/src/js/store/reducer.js
@@ -97,6 +97,17 @@ export default function reducer(state = initialState, action) {
 				loading: false,
 			};
 		}
+		case 'DELETE_PAYMENT_METHOD_IN_HISTORY': {
+			const history = state.history.map((item) => {
+				if (item.paymentMethod === action.payload.value) {
+					return { ...item, paymentMethod: '' };
+				}
+
+				return item;
+			});
+
+			return { ...state, history };
+		}
 		default:
 			return state;
 	}

--- a/client/src/js/utils/payment_method.js
+++ b/client/src/js/utils/payment_method.js
@@ -1,0 +1,7 @@
+import store from '../store/store';
+
+export function IsPaymentMethodExist(value) {
+	const paymentMethod = store.getState('paymentMethod');
+
+	return paymentMethod.some((item) => item.name === value);
+}

--- a/server/src/api/payment_method/payment_method.ctrl.js
+++ b/server/src/api/payment_method/payment_method.ctrl.js
@@ -1,3 +1,4 @@
+import historyDAO from '../../db/DAO/history_DAO.js';
 import paymentMethodDAO from '../../db/DAO/payment_method_DAO.js';
 
 export async function getPaymentMethods(req, res) {
@@ -14,7 +15,12 @@ export async function addPaymentMethod(req, res) {
 
 export async function removePaymentMethod(req, res) {
   const { id } = req.params;
-  await paymentMethodDAO.deletePaymentMethodById(id);
+  const value = await paymentMethodDAO.getPaymentMethodById(id);
+
+  await Promise.all([
+    paymentMethodDAO.deletePaymentMethodById(id),
+    historyDAO.deletePaymentMethodInHistory(value[0].name),
+  ]);
 
   res.status(200).json({ id });
 }

--- a/server/src/db/DAO/history_DAO.js
+++ b/server/src/db/DAO/history_DAO.js
@@ -83,10 +83,27 @@ async function getRecentHistory(year, month, categoryId) {
   }
 }
 
+async function deletePaymentMethodInHistory(value) {
+  try {
+    const [rows] = await promisePool.execute(
+      `
+      UPDATE HISTORY
+      SET paymentMethod = ""
+      WHERE paymentMethod = "${value}"
+      `
+    );
+
+    return rows;
+  } catch (e) {
+    console.error(e);
+  }
+}
+
 export default {
   insertHistory,
   readHistoryByYearMonth,
   deleteHistoryById,
   updateHistoryById,
   getRecentHistory,
+  deletePaymentMethodInHistory,
 };

--- a/server/src/db/DAO/payment_method_DAO.js
+++ b/server/src/db/DAO/payment_method_DAO.js
@@ -2,6 +2,17 @@ import pool from '../loader.js';
 
 const promisePool = pool.promise();
 
+async function getPaymentMethodById(id) {
+  try {
+    const [rows] = await promisePool.execute(`SELECT name FROM PAYMENT_METHOD
+    WHERE id = ${id}`);
+
+    return rows;
+  } catch (e) {
+    console.error(e);
+  }
+}
+
 async function readPaymentMethod() {
   try {
     const [rows] = await promisePool.execute(`SELECT * FROM PAYMENT_METHOD`);
@@ -42,4 +53,5 @@ export default {
   readPaymentMethod,
   insertPaymentMethod,
   deletePaymentMethodById,
+  getPaymentMethodById,
 };

--- a/server/src/mock/mock_generator.js
+++ b/server/src/mock/mock_generator.js
@@ -60,3 +60,59 @@ export function createPaymentMethods() {
 
   return methods;
 }
+
+const paymentMethod = [
+  '국민카드',
+  '현금',
+  '비씨카드',
+  '우리카드',
+  '하나카드',
+  '카카오페이',
+  '배민페이',
+];
+
+const contents = [
+  '정순함박',
+  '엄마밥상',
+  '서브웨이',
+  '버거킹',
+  '북촌손만두',
+  '치마오',
+  '우테캠 월급',
+  '맥도날드',
+  '모스버거',
+  '잠실 설렁탕',
+  '병천 순대국',
+  '만리장성',
+  '롯데마트',
+  '교통비',
+  '감탄커피',
+  '매머드커피',
+  '망원 티라미수',
+  '토도로끼',
+  '용돈',
+];
+
+function getRandomDate(start, end) {
+  const startDate = start.getTime();
+  const endDate = end.getTime();
+
+  return new Date(startDate + Math.random() * (endDate - startDate))
+    .toLocaleDateString()
+    .split('. ')
+    .join('-')
+    .slice(0, -1);
+}
+
+// for (let i = 0; i < 800; i++) {
+//   const history = {
+//     date: getRandomDate(new Date(2021, 7, 1), new Date()),
+//     categoryId: Math.floor(Math.random() * 10 + 1),
+//     content: contents[Math.floor(Math.random() * contents.length)],
+//     paymentMethod:
+//       paymentMethod[Math.floor(Math.random() * paymentMethod.length)],
+//     price: Math.ceil((Math.random() * 300000) / 1000) * 1000,
+//   };
+
+//   history_DAO.insertHistory(history);
+// }


### PR DESCRIPTION
# ✨ 구현 기능 명세
- 결제 수단 삭제 시 해당 항목을 가지고 있던 거래내역의 결제수단을 빈 문자열로 만든다.

# 😭 어려웠던 점
Bulk 업데이트를 하는 SQL 문을 작성하기가 까다로웠다.
<!-- 정확하지 않아도 좋으나 점점 구체화하면 좋을 것 같습니다. 데이터 쌓기! -->

# ⏰ 실제 소요 시간
45m

# 🚧 PR 특이 사항
Closes #44 